### PR TITLE
ヒストグラム生成時の option オブジェクトを追加、一部のオプションを移動

### DIFF
--- a/src/Huehistogram/Huehistogram.py
+++ b/src/Huehistogram/Huehistogram.py
@@ -110,7 +110,6 @@ class HueHistogramOptions:
 def generate_hue_histogram(
     image_path: str,
     out_path: str | None = None,
-    out_dpi: int | None = None,
     verbose: bool = False,
     allow_overwrite: bool = False,
     options: HueHistogramOptions | None = None,
@@ -128,10 +127,6 @@ def generate_hue_histogram(
         None を指定するか未指定だと、かわりに plt.show() を使って表示します。
         拡張子は matplotlib がサポートしていればなんでも使えます。確認しないので、上書き注意！
         例: "/path/to/histogram.png"
-    :param out_dpi: int | None
-        生成するグラフのdpi。
-        None を指定すると matplotlib に任せます。
-        例: 600 (600dpi: 1920 x 1440 くらい)
     :param verbose: bool
         ログを出力するかどうか。
         True であれば進捗などいっぱいメッセージを出します。
@@ -150,6 +145,7 @@ def generate_hue_histogram(
     if options is None:
         options = HueHistogramOptions()
 
+    out_dpi = options.output_dpi
     BRIGHTNESS_MIN = options.pixel_filter.brightness_lower_limit
     BRIGHTNESS_MAX = options.pixel_filter.brightness_upper_limit
     SATURATION_MAX = options.pixel_filter.saturation_upper_limit

--- a/src/Huehistogram/Huehistogram.py
+++ b/src/Huehistogram/Huehistogram.py
@@ -258,6 +258,18 @@ async def generate_hue_histograms(
     # verbose: bool | None = None,
     # allow_overwrite: bool | None = None,
 ) -> bool:
+    """
+    :param input_files:
+        入力するファイルへのパス。
+    :param output_paths: list[str]
+        出力先のパス(ファイル名まで)。input_files の順番でパスを指定してください。
+    :param kwargs:
+        generate_hue_histogram 関数に渡すオプション。同じものが使えます。
+    :return:
+        すべての出力が成功したかどうか。
+        True ならすべて成功しています。
+        False なら1つ以上のエラーが発生しています。
+    """
     failed_files: list[str] = list()
     path_and_future_mapping: dict[str, Future] = dict()
     if len(input_files) != len(output_paths):

--- a/src/Huehistogram/Huehistogram.py
+++ b/src/Huehistogram/Huehistogram.py
@@ -15,15 +15,94 @@ Uint8Info = np.iinfo(np.uint8)
 UINT8_MAX = Uint8Info.max
 UINT8_MIN = Uint8Info.min
 
-# フィルター設定
-SATURATION_MAX = UINT8_MAX - 60  # 彩度の値の上限 (これより大きいのは数えない)
-SATURATION_MIN = UINT8_MIN + 30  # 彩度の値の下限 (これより小さいのは数えない)
-BRIGHTNESS_MAX = UINT8_MAX - 0  # 明るさの値の上限 (これより大きいのは数えない)
-BRIGHTNESS_MIN = UINT8_MIN + 20  # 明るさの値の下限 (これより小さいのは数えない)
 
-# ヒストグラムの設定
-PLOT_SATURATION = 255  # ヒストグラムに使う色の彩度
-PLOT_BRIGHTNESS = 255  # ヒストグラムに使う色の明るさ
+class HueHistogramOptionFilter:
+    """
+    ヒストグラム生成時の画素計算に対するオプション
+
+    引数・戻り値
+    ----------
+    :param saturation_upper_limit: int
+        彩度の上限。これより彩度の大きい画素は数えません。0 <= x <= 255 で指定します。
+        指定しない場合上限を設けず OpenCV が HSV で扱う範囲ですべて使用します。
+        (196 がデフォルトでした)
+    :param saturation_lower_limit: int
+        彩度の下限。これより彩度の小さい画素は数えません。0 <= x <= 255 で指定します。
+        指定しない場合下限を設けず OpenCV が HSV で扱う範囲ですべて使用します。
+        (30 がデフォルトでした)
+    :param brightness_upper_limit: int
+        明度の上限。これより明度の大きい画素は数えません。0 <= x <= 255 で指定します。
+        指定しない場合上限を設けず OpenCV が HSV で扱う範囲ですべて使用します。
+        (255 がデフォルトでした)
+    :param brightness_lower_limit: int
+        明度の下限。これより明度の小さい画素は数えません。0 <= x <= 255 で指定します。
+        指定しない場合下限を設けず OpenCV が HSV で扱う範囲ですべて使用します。
+        (20 がデフォルトでした)
+    """
+
+    saturation_upper_limit: int = UINT8_MAX
+    saturation_lower_limit: int = UINT8_MIN
+    brightness_upper_limit: int = UINT8_MAX
+    brightness_lower_limit: int = UINT8_MIN
+
+    def __init__(
+        self,
+        saturation_upper_limit: int | None = None,
+        saturation_lower_limit: int | None = None,
+        brightness_upper_limit: int | None = None,
+        brightness_lower_limit: int | None = None,
+    ):
+        if saturation_upper_limit is not None:
+            self.saturation_upper_limit = saturation_upper_limit
+        if saturation_lower_limit is not None:
+            self.saturation_lower_limit = saturation_lower_limit
+        if brightness_upper_limit is not None:
+            self.brightness_upper_limit = brightness_upper_limit
+        if brightness_lower_limit is not None:
+            self.brightness_lower_limit = brightness_lower_limit
+
+
+class HueHistogramOptions:
+    """
+    ヒストグラム生成時のオプション
+
+    プロパティ
+    ----------
+    :param pixel_filter: HueHistogramOptionFilter | None
+        ヒストグラムを描画する前、画素を数えるときのフィルタ。
+        None や指定しない場合 HueHistogramOptionFilter のデフォルトを使用します。
+    :param bar_saturation: int
+        ヒストグラムを生成するときに使う、棒グラフの色の彩度。
+    :param bar_brightness: int
+        ヒストグラムを生成するときに使う、棒グラフの色の明度。
+    :param output_dpi: int
+        ヒストグラムを生成するときの画素密度(dpi)。
+        None や指定しない場合 matplotlib の挙動に任せます。
+        例: 600 (600dpi: 1920 x 1440 くらい)
+    """
+
+    pixel_filter: HueHistogramOptionFilter = HueHistogramOptionFilter()
+    bar_saturation: int = 255
+    bar_brightness: int = 255
+    output_dpi: int | None = None
+
+    def __init__(
+        self,
+        pixel_filter: HueHistogramOptionFilter | None = None,
+        bar_saturation: int | None = None,
+        bar_brightness: int | None = None,
+        output_dpi: int | None = None,
+    ):
+        if pixel_filter is not None:
+            self.pixel_filter = pixel_filter
+        else:
+            self.pixel_filter = HueHistogramOptionFilter()
+        if bar_saturation is not None:
+            self.bar_saturation = bar_saturation
+        if bar_brightness is not None:
+            self.bar_brightness = bar_brightness
+        if output_dpi is not None:
+            self.output_dpi = output_dpi
 
 
 # @memory_profiler.profile
@@ -34,6 +113,7 @@ def generate_hue_histogram(
     out_dpi: int | None = None,
     verbose: bool = False,
     allow_overwrite: bool = False,
+    options: HueHistogramOptions | None = None,
 ) -> Axes | None:
     """
     画像ファイルから彩度ヒストグラムを生成して、表示・保存する
@@ -60,9 +140,22 @@ def generate_hue_histogram(
         出力先の画像が存在する場合に上書きするかどうか。
         True だと確認せず上書きします。
         False だと上書きせず警告します。
+    :param options: HueHistogramOptions | None
+        ヒストグラム生成時に使うオプション。
+        指定しない場合はデフォルトの設定を使います。
     :return: matplotlib.axes._axe.Axes
         描画したヒストグラムの Axes オブジェクト。凡例は削除され、タテ・ヨコ軸、タイトルは設定された状態で返ります
     """
+
+    if options is None:
+        options = HueHistogramOptions()
+
+    BRIGHTNESS_MIN = options.pixel_filter.brightness_lower_limit
+    BRIGHTNESS_MAX = options.pixel_filter.brightness_upper_limit
+    SATURATION_MAX = options.pixel_filter.saturation_upper_limit
+    SATURATION_MIN = options.pixel_filter.saturation_lower_limit
+    PLOT_SATURATION = options.bar_saturation
+    PLOT_BRIGHTNESS = options.bar_brightness
 
     # 上書きを防止する
     if os.path.exists(out_path) and not allow_overwrite:

--- a/src/huehistogram_cli.py
+++ b/src/huehistogram_cli.py
@@ -56,14 +56,20 @@ if __name__ == "__main__":
         print(
             "    python huehistogram_cli.py -i [path/to/image.jpg] [image_2.jpg] -o [path/to/histograms/]"
         )
+        print("  To show full usage:")
+        print("    python huehistogram_cli.py -h")
         return
 
     if len(sys.argv) <= 1:
         show_help()
         exit(SIG_INVALID_ARGS)
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument("args", nargs="*")
+    parser = argparse.ArgumentParser(description="Generate hue histogram")
+    parser.add_argument(
+        "args",
+        nargs="*",
+        help="path(s) to some input files and output directory/file. The last argument will be used as output path if you do not specify -i and -o explicitly.",
+    )
     arg_input_group = parser.add_mutually_exclusive_group()
     arg_input_group.add_argument(
         "-i", "--input", help="path(s) to input image files", nargs="+"

--- a/src/huehistogram_cli.py
+++ b/src/huehistogram_cli.py
@@ -88,7 +88,32 @@ if __name__ == "__main__":
         help="Do overwrite files if a file exists on destination",
         action="store_true",
     )
-    parser.add_argument("-d", "--dpi", help="the dpi to output histograms")
+    arg_options_group = parser.add_argument_group("Histogram options")
+    arg_options_group.add_argument("-d", "--dpi", help="the dpi to output histograms")
+    arg_options_group.add_argument(
+        "--brightness-upper-limit",
+        help="the upper limit of pixel brightness. Pixels with more brightness will not be counted.",
+    )
+    arg_options_group.add_argument(
+        "--brightness-lower-limit",
+        help="the lower limit of pixel brightness. Pixels with less brightness will not be counted.",
+    )
+    arg_options_group.add_argument(
+        "--saturation-upper-limit",
+        help="the upper limit of pixel saturation. Pixels with more saturation will not be counted.",
+    )
+    arg_options_group.add_argument(
+        "--saturation-lower-limit",
+        help="the lower limit of pixel saturation. Pixels with less saturation will not be counted.",
+    )
+    arg_options_group.add_argument(
+        "--bar-saturation",
+        help="the saturation value to use when drawing histogram bars",
+    )
+    arg_options_group.add_argument(
+        "--bar-brightness",
+        help="the brightness value to use when drawing histogram bars",
+    )
     args = parser.parse_args()
 
     input_files = []
@@ -153,6 +178,18 @@ if __name__ == "__main__":
     options = Huehistogram.HueHistogramOptions()
     if args.dpi:
         options.output_dpi = args.dpi
+    if args.brightness_upper_limit:
+        options.brightness_upper_limit = args.brightness_upper_limit
+    if args.brightness_lower_limit:
+        options.brightness_lower_limit = args.brightness_lower_limit
+    if args.saturation_upper_limit:
+        options.saturation_upper_limit = args.saturation_upper_limit
+    if args.saturation_lower_limit:
+        options.saturation_lower_limit = args.saturation_lower_limit
+    if args.bar_saturation:
+        options.bar_saturation = args.bar_saturation
+    if args.bar_brightness:
+        options.bar_brightness = args.bar_brightness
 
     res = asyncio.run(
         Huehistogram.generate_hue_histograms(

--- a/src/huehistogram_cli.py
+++ b/src/huehistogram_cli.py
@@ -92,7 +92,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     input_files = []
-    output_dpi = args.dpi
     is_verbose = args.verbose
     input_arg = args.input
     output_arg = args.output
@@ -151,13 +150,17 @@ if __name__ == "__main__":
         print(f"Input file {nonexistent_input_file} does not exist!")
         exit(SIG_INVALID_ARGS)
 
+    options = Huehistogram.HueHistogramOptions()
+    if args.dpi:
+        options.output_dpi = args.dpi
+
     res = asyncio.run(
         Huehistogram.generate_hue_histograms(
             input_files=input_files,
             output_paths=output_paths,
-            out_dpi=output_dpi,
             verbose=is_verbose,
             allow_overwrite=args.force_overwrite,
+            options=options,
         )
     )
     if res:


### PR DESCRIPTION
# 概要

ヒストグラムを生成するときのフィルタ設定を option オブジェクトに移動
**破壊的変更**: 
- ``output_dpi `` は ``generate_hue_histogram`` 関数の引数から削除し、引数 ``options`` (``HueHistogramOptions.output_dpi``) に移動
  - このコミット→ https://github.com/NitCelcius/HueHistogram/commit/e1cc5b063c4572ec057d1add65a776653570045e

# 解決する issue たち
Merging this PR will:
- close #7